### PR TITLE
TweenOps is now open for any T : Numeric

### DIFF
--- a/src/main/scala/me/arcticlight/animations/ScalaTween.scala
+++ b/src/main/scala/me/arcticlight/animations/ScalaTween.scala
@@ -34,8 +34,34 @@ object ScalaTween {
     def lease(other: T, fraction: Float, fease: (Float) => Float): T
       = this + (other - this) * fease(fraction)
   }
+
+  /**
+   * Implicitly convert any `TweenOps[T]` back to the underlying `T`.
+   *
+   * This implicit conversion is basically a reminder to the compiler
+   * that any `TweenOps` for some `T <: TweenOps` is also a `T`, which the
+   * compiler can't seem to prove on its' own. Since the type param on
+   * `TweenOps` gets erased at compile-time, this function never actually
+   * gets called.
+   *
+   * Also, note that while IntelliJ thinks this is wrong, the actual Scala
+   * compiler understands it. Probably should disable that warning.
+   *
+   * @param ops an instance of [[TweenOps]]
+   * @tparam T the underlying type on which that [[TweenOps]] operates
+   * @return the given `TweenOps`, but converted so that the compiler
+   *         can understand it as a `T`
+   */
   implicit def unwrapTweenOps[T <: TweenOps[T]](ops: TweenOps[T]): T = ops
-  implicit def detwopsNumeric[A](twops: TwopsyNumeric[A]): A = twops.value
+
+  /**
+   * Unpack a [[TwopsyNumeric]] to get back the underlying [[Numeric]].
+   *
+   * @param ops A [[TwopsyNumeric]]
+   * @tparam A the underlying type `A : Numeric`
+   * @return the underlying value wrapped by `ops`
+   */
+  implicit def detwopsNumeric[A](ops: TwopsyNumeric[A]): A = ops.value
 
   /**
    * Implicitly adds [[TweenOps]][A] to any `A` with [[Numeric]].
@@ -49,7 +75,14 @@ object ScalaTween {
    */
   implicit class TwopsyNumeric[A : Numeric](val value: A)
   extends TweenOps[TwopsyNumeric[A]] {
-
+    // Basically, just wrap all of the underlying numeric value's
+    // pre-existing mathematical operations. I wish this wasn't necessary,
+    // but apparently Scalac is not quite smart enough to construct a type
+    // proof that         +, - :: (Numeric a) => a -> a -> a
+    // is equivalent to   +, - :: (TweenOps a) => a -> a -> a.
+    //
+    // So we have to do it this way.
+    //  – Hawk
     override def *(fraction: Float): TwopsyNumeric[A]
       = value * fraction
     override def +(other: TwopsyNumeric[A]): TwopsyNumeric[A]

--- a/src/main/scala/me/arcticlight/animations/ScalaTween.scala
+++ b/src/main/scala/me/arcticlight/animations/ScalaTween.scala
@@ -35,15 +35,15 @@ object ScalaTween {
       = this + (other - this) * fease(fraction)
   }
   implicit def unwrapTweenOps[T <: TweenOps[T]](ops: TweenOps[T]): T = ops
-  implicit def removeTwops(twops: FloatWithTwops): Float = twops.float
-  implicit class FloatWithTwops(val float: Float)
-  extends TweenOps[FloatWithTwops] {
-    def *(fraction: Float): FloatWithTwops
-      = float * fraction
-    def +(other: FloatWithTwops): FloatWithTwops
-      = float * other
-    def -(other: FloatWithTwops): FloatWithTwops
-      = float - other
+  implicit def detwopsNumeric[A](twops: TwopsyNumeric[A]): A = twops.value
+  implicit class TwopsyNumeric[A](val value: A)(implicit num: Numeric[A])
+  extends TweenOps[TwopsyNumeric[A]] {
+    def *(fraction: Float): TwopsyNumeric[A]
+      = value * fraction
+    def +(other: TwopsyNumeric[A]): TwopsyNumeric[A]
+      = value + other
+    def -(other: TwopsyNumeric[A]): TwopsyNumeric[A]
+      = value - other
   }
   class AnimationTarget[T <: TweenOps[T]](var value: T) {
   }

--- a/src/main/scala/me/arcticlight/animations/ScalaTween.scala
+++ b/src/main/scala/me/arcticlight/animations/ScalaTween.scala
@@ -36,14 +36,27 @@ object ScalaTween {
   }
   implicit def unwrapTweenOps[T <: TweenOps[T]](ops: TweenOps[T]): T = ops
   implicit def detwopsNumeric[A](twops: TwopsyNumeric[A]): A = twops.value
-  implicit class TwopsyNumeric[A](val value: A)(implicit num: Numeric[A])
+
+  /**
+   * Implicitly adds [[TweenOps]][A] to any `A` with [[Numeric]].
+   *
+   * This is possible because any typeclass implementing [[Numeric]] should
+   * already have `+`, `-`, and `*` operations that [[TweenOps]] can use.
+   *
+   * @param value the underlying numeric value
+   * @tparam A a type extending [[Numeric]]
+   * @author Hawk Weisman
+   */
+  implicit class TwopsyNumeric[A : Numeric](val value: A)
   extends TweenOps[TwopsyNumeric[A]] {
-    def *(fraction: Float): TwopsyNumeric[A]
+
+    override def *(fraction: Float): TwopsyNumeric[A]
       = value * fraction
-    def +(other: TwopsyNumeric[A]): TwopsyNumeric[A]
+    override def +(other: TwopsyNumeric[A]): TwopsyNumeric[A]
       = value + other
-    def -(other: TwopsyNumeric[A]): TwopsyNumeric[A]
+    override def -(other: TwopsyNumeric[A]): TwopsyNumeric[A]
       = value - other
+
   }
   class AnimationTarget[T <: TweenOps[T]](var value: T) {
   }

--- a/src/main/scala/me/arcticlight/animations/ScalaTween.scala
+++ b/src/main/scala/me/arcticlight/animations/ScalaTween.scala
@@ -35,16 +35,15 @@ object ScalaTween {
       = this + (other - this) * fease(fraction)
   }
   implicit def unwrapTweenOps[T <: TweenOps[T]](ops: TweenOps[T]): T = ops
-  implicit def floatToTwops(float: Float): TweenOps[FloatWithTwops]
-    = FloatWithTwops(float)
   implicit def removeTwops(twops: FloatWithTwops): Float = twops.float
-  final case class FloatWithTwops(float: Float) extends TweenOps[FloatWithTwops] {
+  implicit class FloatWithTwops(val float: Float)
+  extends TweenOps[FloatWithTwops] {
     def *(fraction: Float): FloatWithTwops
-      = FloatWithTwops(float * fraction)
+      = float * fraction
     def +(other: FloatWithTwops): FloatWithTwops
-      = FloatWithTwops(float * other)
+      = float * other
     def -(other: FloatWithTwops): FloatWithTwops
-      = FloatWithTwops(float - other)
+      = float - other
   }
   class AnimationTarget[T <: TweenOps[T]](var value: T) {
   }


### PR DESCRIPTION
This generalises `FloatWithTwops` to all types `T` such that `T : Numeric`. It also makes the `TwopsyNumeric` class implicit, negating one of the two implicit conversion functions.
