### PR TITLE
Misc small improvements

### DIFF
--- a/src/main/scala/me/arcticlight/animations/ScalaTween.scala
+++ b/src/main/scala/me/arcticlight/animations/ScalaTween.scala
@@ -34,8 +34,34 @@ object ScalaTween {
     def lease(other: T, fraction: Float, fease: (Float) => Float): T
       = this + (other - this) * fease(fraction)
   }
+
+  /**
+   * Implicitly convert any `TweenOps[T]` back to the underlying `T`.
+   *
+   * This implicit conversion is basically a reminder to the compiler
+   * that any `TweenOps` for some `T <: TweenOps` is also a `T`, which the
+   * compiler can't seem to prove on its' own. Since the type param on
+   * `TweenOps` gets erased at compile-time, this function never actually
+   * gets called.
+   *
+   * Also, note that while IntelliJ thinks this is wrong, the actual Scala
+   * compiler understands it. Probably should disable that warning.
+   *
+   * @param ops an instance of [[TweenOps]]
+   * @tparam T the underlying type on which that [[TweenOps]] operates
+   * @return the given `TweenOps`, but converted so that the compiler
+   *         can understand it as a `T`
+   */
   implicit def unwrapTweenOps[T <: TweenOps[T]](ops: TweenOps[T]): T = ops
-  implicit def detwopsNumeric[A](twops: TwopsyNumeric[A]): A = twops.value
+
+  /**
+   * Unpack a [[TwopsyNumeric]] to get back the underlying [[Numeric]].
+   *
+   * @param ops A [[TwopsyNumeric]]
+   * @tparam A the underlying type `A : Numeric`
+   * @return the underlying value wrapped by `ops`
+   */
+  implicit def detwopsNumeric[A](ops: TwopsyNumeric[A]): A = ops.value
 
   /**
    * Implicitly adds [[TweenOps]][A] to any `A` with [[Numeric]].
@@ -49,7 +75,14 @@ object ScalaTween {
    */
   implicit class TwopsyNumeric[A : Numeric](val value: A)
   extends TweenOps[TwopsyNumeric[A]] {
-
+    // Basically, just wrap all of the underlying numeric value's
+    // pre-existing mathematical operations. I wish this wasn't necessary,
+    // but apparently Scalac is not quite smart enough to construct a type
+    // proof that         +, - :: (Numeric a) => a -> a -> a
+    // is equivalent to   +, - :: (TweenOps a) => a -> a -> a.
+    //
+    // So we have to do it this way.
+    //  – Hawk
     override def *(fraction: Float): TwopsyNumeric[A]
       = value * fraction
     override def +(other: TwopsyNumeric[A]): TwopsyNumeric[A]

--- a/src/main/scala/me/arcticlight/animations/ScalaTween.scala
+++ b/src/main/scala/me/arcticlight/animations/ScalaTween.scala
@@ -102,6 +102,40 @@ object ScalaTween {
      */
     override def add(a: Float, b: Float): Float = a + b
   }
+  // TODO: finish this, requires TweenOps.mult() to take a
+  //Fractional or Numeric as the left scalar.  
+  // class FractionalsAreTweenOpsable[A : Fractional]
+  // extends TweenOps[A] {
+  //   /**
+  //    * Scalar multiply (Tween operation) multiplies this value by a fraction
+  //    * and returns the result
+  //    * @param a The value to multiply
+  //    * @param f A [[Float]] value between 0 and 1, inclusive
+  //    * @return a T scaled by multiplying it with the scalar `fraction` amount
+  //    */
+  //   override def mult(a: A, b: A): A
+  //     = implicitly[Fractional[A]].times(a,b)
+  //
+  //   /**
+  //    * Subtract (Tween operation) subtracts the parameter from this object
+  //    * and returns the result.
+  //    * @param a The first value to work with
+  //    * @param b Another [[Float]] to subtract from this one
+  //    * @return The result of subtracting `b` from `a`
+  //    */
+  //   override def subt(a: A, b: A): A
+  //     = implicitly[Fractional[A]].minus(a,b)
+  //
+  //   /**
+  //    * Add (Tween operation) adds together this object and the parameter and
+  //    * returns the result
+  //    * @param a The first value to work with
+  //    * @param b Another [[Float]] to add to this one
+  //    * @return The result of adding together `this` and `other`
+  //    */
+  //   override def add(a: A, b: A): A
+  //     = implicitly[Fractional[A]].plus(a,b)
+  // }
 
   class AnimationTarget[T : TweenOps](var value: T)
   extends TweenOps[T] {

--- a/src/main/scala/me/arcticlight/animations/ScalaTween.scala
+++ b/src/main/scala/me/arcticlight/animations/ScalaTween.scala
@@ -35,15 +35,15 @@ object ScalaTween {
       = this + (other - this) * fease(fraction)
   }
   implicit def unwrapTweenOps[T <: TweenOps[T]](ops: TweenOps[T]): T = ops
-  implicit def removeTwops(twops: FloatWithTwops): Float = twops.float
-  implicit class FloatWithTwops(val float: Float)
-  extends TweenOps[FloatWithTwops] {
-    def *(fraction: Float): FloatWithTwops
-      = float * fraction
-    def +(other: FloatWithTwops): FloatWithTwops
-      = float * other
-    def -(other: FloatWithTwops): FloatWithTwops
-      = float - other
+  implicit def detwopsNumeric[A](twops: TwopsyNumeric[A]): A = twops.value
+  implicit class TwopsyNumeric[A](val value: A)(implicit num: Numeric[A])
+  extends TweenOps[TwopsyNumeric[A]] {
+    def *(fraction: Float): TwopsyNumeric[A]
+      = value * fraction
+    def +(other: TwopsyNumeric[A]): TwopsyNumeric[A]
+      = value + other
+    def -(other: TwopsyNumeric[A]): TwopsyNumeric[A]
+      = value - other
   }
   class AnimationTarget[T <: TweenOps[T]](var value: T) {
   }

--- a/src/main/scala/me/arcticlight/animations/ScalaTween.scala
+++ b/src/main/scala/me/arcticlight/animations/ScalaTween.scala
@@ -1,111 +1,10 @@
 package me.arcticlight.animations
+
+import me.arcticlight.animations.TweenOps.FloatHasTweenOps
+
 import scala.language.implicitConversions
 
 object ScalaTween {
-
-  trait TweenOps[A]  {
-    /**
-     * Scalar multiply (Tween operation) multiplies this value by a fraction
-     * and returns the result
-     * @param a The value to multiply
-     * @param f A [[Float]] value between 0 and 1, inclusive
-     * @return a T scaled by multiplying it with the scalar `fraction` amount
-     */
-    def mult[B : Fractional](a: A, b: B): A
-
-    /**
-     * Add (Tween operation) adds together this object and the parameter and
-     * returns the result
-     * @param a The first value to work with
-     * @param b Another [[T]] to add to this one
-     * @return The result of adding together `a` and `b`
-     */
-    def add(a: A, b: A): A
-
-    /**
-     * Subtract (Tween operation) subtracts the parameter from this object
-     * and returns the result.
-     * @param a The first value to work with
-     * @param b Another [[T]] to subtract from this one
-     * @return The result of subtracting `b` from `a`
-     */
-    def subt(a: A, b: A): A
-
-    /**
-     * Perform linear interpolation using TweenOps.
-     * @param a The value to start with
-     * @param b the other [[T]] with which to lerp to
-     */
-    def lerp(a: A, b: A, fraction: Float): A
-      = add(a, mult(subt(b,a), fraction))
-
-    def withEase(ease: (Float) => Float): WithEase = new WithEase(ease)
-
-    class WithEase(ease: (Float) => Float) extends TweenOps[A] {
-      /**
-       * Scalar multiply (Tween operation) multiplies this value by a fraction
-       * and returns the result
-       * @param a The value to multiply
-       * @param f A [[Float]] value between 0 and 1, inclusive
-       * @return a T scaled by multiplying it with the scalar `f` amount
-       */
-      override def mult[B : Fractional](a: A, b: B): A
-        = TweenOps.this.mult(a,b)
-
-      /**
-       * Subtract (Tween operation) subtracts the parameter from this object
-       * and returns the result.
-       * @param a The first value to work with
-       * @param b Another [[T]] to subtract from this one
-       * @return The result of subtracting `b` from `a`
-       */
-      override def subt(a: A, b: A): A
-        = TweenOps.this.subt(a,b)
-
-      /**
-       * Add (Tween operation) adds together this object and the parameter
-       * and returns the result
-       * @param a The first value to work with
-       * @param b Another [[T]] to add to this one
-       * @return The result of adding together `a` and `b`
-       */
-      override def add(a: A, b: A): A
-        = TweenOps.this.add(a,b)
-
-      override def lerp(a: A, b: A, f: Float): A
-        = add(a, mult(subt(b,a), ease(f)))
-    }
-  }
-
-  implicit object FloatHasTweenOps extends TweenOps[Float] {
-    /**
-     * Scalar multiply (Tween operation) multiplies this value by a fraction
-     * and returns the result
-     * @param a The value to multiply
-     * @param f A [[Float]] value between 0 and 1, inclusive
-     * @return a T scaled by multiplying it with the scalar `fraction` amount
-     */
-    override def mult[B : Fractional](a: Float, b: B): Float
-      = a * implicitly[Numeric[B]].toFloat(b)
-
-    /**
-     * Subtract (Tween operation) subtracts the parameter from this object
-     * and returns the result.
-     * @param a The first value to work with
-     * @param b Another [[Float]] to subtract from this one
-     * @return The result of subtracting `b` from `a`
-     */
-    override def subt(a: Float, b: Float): Float = a * b
-
-    /**
-     * Add (Tween operation) adds together this object and the parameter and
-     * returns the result
-     * @param a The first value to work with
-     * @param b Another [[Float]] to add to this one
-     * @return The result of adding together `this` and `other`
-     */
-    override def add(a: Float, b: Float): Float = a + b
-  }
   // TODO: finish this, requires TweenOps.mult() to take a
   //Fractional or Numeric as the left scalar.
   // class FractionalsAreTweenOpsable[A : Fractional]
@@ -150,7 +49,7 @@ object ScalaTween {
      * @param f A [[Float]] value between 0 and 1, inclusive
      * @return a T scaled by multiplying it with the scalar `fraction` amount
      */
-    override def mult[B : Fractional](a: T, b: B): T
+    override def mult[B : Fractional](a: A, b: B): A
       = implicitly[TweenOps[A]].mult(a,b)
 
     /**

--- a/src/main/scala/me/arcticlight/animations/ScalaTween.scala
+++ b/src/main/scala/me/arcticlight/animations/ScalaTween.scala
@@ -5,7 +5,8 @@ object ScalaTween {
 
   trait TweenOps[T]  {
     /**
-     * Scalar multiply (Tween operation) multiplies this value by a fraction and returns the result
+     * Scalar multiply (Tween operation) multiplies this value by a fraction
+     * and returns the result
      * @param a The value to multiply
      * @param f A [[Float]] value between 0 and 1, inclusive
      * @return a T scaled by multiplying it with the scalar `fraction` amount
@@ -13,7 +14,8 @@ object ScalaTween {
     def mult(a: T, f: Float): T
 
     /**
-     * Add (Tween operation) adds together this object and the parameter and returns the result
+     * Add (Tween operation) adds together this object and the parameter and
+     * returns the result
      * @param a The first value to work with
      * @param b Another [[T]] to add to this one
      * @return The result of adding together `a` and `b`
@@ -21,7 +23,8 @@ object ScalaTween {
     def add(a: T, b: T): T
 
     /**
-     * Subtract (Tween operation) subtracts the parameter from this object and returns the result.
+     * Subtract (Tween operation) subtracts the parameter from this object
+     * and returns the result.
      * @param a The first value to work with
      * @param b Another [[T]] to subtract from this one
      * @return The result of subtracting `b` from `a`
@@ -40,7 +43,8 @@ object ScalaTween {
 
     class WithEase(ease: (Float) => Float) extends TweenOps[T] {
       /**
-       * Scalar multiply (Tween operation) multiplies this value by a fraction and returns the result
+       * Scalar multiply (Tween operation) multiplies this value by a fraction
+       * and returns the result
        * @param a The value to multiply
        * @param f A [[Float]] value between 0 and 1, inclusive
        * @return a T scaled by multiplying it with the scalar `f` amount
@@ -48,7 +52,8 @@ object ScalaTween {
       override def mult(a: T, f: Float): T = TweenOps.this.mult(a,f)
 
       /**
-       * Subtract (Tween operation) subtracts the parameter from this object and returns the result.
+       * Subtract (Tween operation) subtracts the parameter from this object
+       * and returns the result.
        * @param a The first value to work with
        * @param b Another [[T]] to subtract from this one
        * @return The result of subtracting `b` from `a`
@@ -56,20 +61,23 @@ object ScalaTween {
       override def subt(a: T, b: T): T = TweenOps.this.subt(a,b)
 
       /**
-       * Add (Tween operation) adds together this object and the parameter and returns the result
+       * Add (Tween operation) adds together this object and the parameter
+       * and returns the result
        * @param a The first value to work with
        * @param b Another [[T]] to add to this one
        * @return The result of adding together `a` and `b`
        */
       override def add(a: T, b: T): T = TweenOps.this.add(a,b)
 
-      override def lerp(a: T, b: T, f: Float): T = add(a, mult(subt(b,a), ease(f)))
+      override def lerp(a: T, b: T, f: Float): T
+        = add(a, mult(subt(b,a), ease(f)))
     }
   }
 
   implicit object FloatHasTweenOps extends TweenOps[Float] {
     /**
-     * Scalar multiply (Tween operation) multiplies this value by a fraction and returns the result
+     * Scalar multiply (Tween operation) multiplies this value by a fraction
+     * and returns the result
      * @param a The value to multiply
      * @param f A [[Float]] value between 0 and 1, inclusive
      * @return a T scaled by multiplying it with the scalar `fraction` amount
@@ -77,7 +85,8 @@ object ScalaTween {
     override def mult(a: Float, f: Float): Float = a * f
 
     /**
-     * Subtract (Tween operation) subtracts the parameter from this object and returns the result.
+     * Subtract (Tween operation) subtracts the parameter from this object
+     * and returns the result.
      * @param a The first value to work with
      * @param b Another [[Float]] to subtract from this one
      * @return The result of subtracting `b` from `a`
@@ -85,7 +94,8 @@ object ScalaTween {
     override def subt(a: Float, b: Float): Float = a * b
 
     /**
-     * Add (Tween operation) adds together this object and the parameter and returns the result
+     * Add (Tween operation) adds together this object and the parameter and
+     * returns the result
      * @param a The first value to work with
      * @param b Another [[Float]] to add to this one
      * @return The result of adding together `this` and `other`
@@ -96,7 +106,8 @@ object ScalaTween {
   class AnimationTarget[T : TweenOps](var value: T)
   extends TweenOps[T] {
     /**
-     * Scalar multiply (Tween operation) multiplies this value by a fraction and returns the result
+     * Scalar multiply (Tween operation) multiplies this value by a fraction
+     * and returns the result
      * @param a The value to multiply
      * @param f A [[Float]] value between 0 and 1, inclusive
      * @return a T scaled by multiplying it with the scalar `fraction` amount
@@ -105,7 +116,8 @@ object ScalaTween {
       = implicitly[TweenOps[T]].mult(a,f)
 
     /**
-     * Subtract (Tween operation) subtracts the parameter from this object and returns the result.
+     * Subtract (Tween operation) subtracts the parameter from this object
+     * and returns the result.
      * @param a The first value to work with
      * @param b Another [[T]] to subtract from this one
      * @return The result of subtracting `b` from `a`
@@ -114,7 +126,8 @@ object ScalaTween {
       = implicitly[TweenOps[T]].subt(a,b)
 
     /**
-     * Add (Tween operation) adds together this object and the parameter and returns the result
+     * Add (Tween operation) adds together this object and the parameter
+     * and returns the result
      * @param a The first value to work with
      * @param b Another [[T]] to add to this one
      * @return The result of adding together `a` and `b`

--- a/src/main/scala/me/arcticlight/animations/ScalaTween.scala
+++ b/src/main/scala/me/arcticlight/animations/ScalaTween.scala
@@ -141,8 +141,8 @@ object ScalaTween {
   //     = implicitly[Fractional[A]].plus(a,b)
   // }
 
-  class AnimationTarget[T : TweenOps](var value: T)
-  extends TweenOps[T] {
+  class AnimationTarget[A : TweenOps](var value: A)
+  extends TweenOps[A] {
     /**
      * Scalar multiply (Tween operation) multiplies this value by a fraction
      * and returns the result
@@ -151,7 +151,7 @@ object ScalaTween {
      * @return a T scaled by multiplying it with the scalar `fraction` amount
      */
     override def mult[B : Fractional](a: T, b: B): T
-      = implicitly[TweenOps[T]].mult(a,b)
+      = implicitly[TweenOps[A]].mult(a,b)
 
     /**
      * Subtract (Tween operation) subtracts the parameter from this object
@@ -160,8 +160,8 @@ object ScalaTween {
      * @param b Another [[T]] to subtract from this one
      * @return The result of subtracting `b` from `a`
      */
-    override def subt(a: T, b: T): T
-      = implicitly[TweenOps[T]].subt(a,b)
+    override def subt(a: A, b: A): A
+      = implicitly[TweenOps[A]].subt(a,b)
 
     /**
      * Add (Tween operation) adds together this object and the parameter
@@ -170,18 +170,18 @@ object ScalaTween {
      * @param b Another [[T]] to add to this one
      * @return The result of adding together `a` and `b`
      */
-    override def add(a: T, b: T): T
-      = implicitly[TweenOps[T]].add(a,b)
+    override def add(a: A, b: A): A
+      = implicitly[TweenOps[A]].add(a,b)
 
-    def +(b: T): T = add(this.value, b)
-    def -(b: T): T = subt(this.value,b)
-    def *[B : Fractional](b: B): T = mult(this.value, b)
+    def +(b: A): A = add(this.value, b)
+    def -(b: A): A = subt(this.value,b)
+    def *[B : Fractional](b: B): A = mult(this.value, b)
 
-    def +=(b: T): Unit = {
+    def +=(b: A): Unit = {
       this.value = add(this.value, b)
     }
 
-    def -=(b: T): Unit = {
+    def -=(b: A): Unit = {
       this.value = subt(this.value, b)
     }
 

--- a/src/main/scala/me/arcticlight/animations/ScalaTween.scala
+++ b/src/main/scala/me/arcticlight/animations/ScalaTween.scala
@@ -67,7 +67,8 @@ object ScalaTween {
     }
   }
 
-  implicit class FloatHasTweenOps(value: Float) extends TweenOps[Float] {
+  implicit object FloatHasTweenOps
+  extends TweenOps[Float] {
     /**
      * Scalar multiply (Tween operation) multiplies this value by a fraction and returns the result
      * @param a The value to multiply

--- a/src/main/scala/me/arcticlight/animations/ScalaTween.scala
+++ b/src/main/scala/me/arcticlight/animations/ScalaTween.scala
@@ -5,41 +5,6 @@ import me.arcticlight.animations.TweenOps.FloatHasTweenOps
 import scala.language.implicitConversions
 
 object ScalaTween {
-  // TODO: finish this, requires TweenOps.mult() to take a
-  //Fractional or Numeric as the left scalar.
-  // class FractionalsAreTweenOpsable[A : Fractional]
-  // extends TweenOps[A] {
-  //   /**
-  //    * Scalar multiply (Tween operation) multiplies this value by a fraction
-  //    * and returns the result
-  //    * @param a The value to multiply
-  //    * @param f A [[Float]] value between 0 and 1, inclusive
-  //    * @return a T scaled by multiplying it with the scalar `fraction` amount
-  //    */
-  //   override def mult(a: A, b: A): A
-  //     = implicitly[Fractional[A]].times(a,b)
-  //
-  //   /**
-  //    * Subtract (Tween operation) subtracts the parameter from this object
-  //    * and returns the result.
-  //    * @param a The first value to work with
-  //    * @param b Another [[Float]] to subtract from this one
-  //    * @return The result of subtracting `b` from `a`
-  //    */
-  //   override def subt(a: A, b: A): A
-  //     = implicitly[Fractional[A]].minus(a,b)
-  //
-  //   /**
-  //    * Add (Tween operation) adds together this object and the parameter and
-  //    * returns the result
-  //    * @param a The first value to work with
-  //    * @param b Another [[Float]] to add to this one
-  //    * @return The result of adding together `this` and `other`
-  //    */
-  //   override def add(a: A, b: A): A
-  //     = implicitly[Fractional[A]].plus(a,b)
-  // }
-
   class AnimationTarget[A : TweenOps](var value: A)
   extends TweenOps[A] {
     /**

--- a/src/main/scala/me/arcticlight/animations/ScalaTween.scala
+++ b/src/main/scala/me/arcticlight/animations/ScalaTween.scala
@@ -67,7 +67,7 @@ object ScalaTween {
     }
   }
 
-  implicit class FloatHasTweenOps(value: Float) extends TweenOps[Float] {
+  implicit object FloatHasTweenOps extends TweenOps[Float] {
     /**
      * Scalar multiply (Tween operation) multiplies this value by a fraction and returns the result
      * @param a The value to multiply

--- a/src/main/scala/me/arcticlight/animations/ScalaTween.scala
+++ b/src/main/scala/me/arcticlight/animations/ScalaTween.scala
@@ -93,14 +93,16 @@ object ScalaTween {
     override def add(a: Float, b: Float): Float = a + b
   }
 
-  class AnimationTarget[T](var value: T)(implicit to: TweenOps[T]) extends TweenOps[T] {
+  class AnimationTarget[T : TweenOps](var value: T)
+  extends TweenOps[T] {
     /**
      * Scalar multiply (Tween operation) multiplies this value by a fraction and returns the result
      * @param a The value to multiply
      * @param f A [[Float]] value between 0 and 1, inclusive
      * @return a T scaled by multiplying it with the scalar `fraction` amount
      */
-    override def mult(a: T, f: Float): T = to.mult(a,f)
+    override def mult(a: T, f: Float): T
+      = implicitly[TweenOps[T]].mult(a,f)
 
     /**
      * Subtract (Tween operation) subtracts the parameter from this object and returns the result.
@@ -108,7 +110,8 @@ object ScalaTween {
      * @param b Another [[T]] to subtract from this one
      * @return The result of subtracting `b` from `a`
      */
-    override def subt(a: T, b: T): T = to.subt(a,b)
+    override def subt(a: T, b: T): T
+      = implicitly[TweenOps[T]].subt(a,b)
 
     /**
      * Add (Tween operation) adds together this object and the parameter and returns the result
@@ -116,7 +119,8 @@ object ScalaTween {
      * @param b Another [[T]] to add to this one
      * @return The result of adding together `a` and `b`
      */
-    override def add(a: T, b: T): T = to.add(a,b)
+    override def add(a: T, b: T): T
+      = implicitly[TweenOps[T]].add(a,b)
 
     def +(b: T): T = add(this.value, b)
     def -(b: T): T = subt(this.value,b)

--- a/src/main/scala/me/arcticlight/animations/ScalaTween.scala
+++ b/src/main/scala/me/arcticlight/animations/ScalaTween.scala
@@ -36,14 +36,27 @@ object ScalaTween {
   }
   implicit def unwrapTweenOps[T <: TweenOps[T]](ops: TweenOps[T]): T = ops
   implicit def detwopsNumeric[A](twops: TwopsyNumeric[A]): A = twops.value
-  implicit class TwopsyNumeric[A](val value: A)(implicit num: Numeric[A])
+
+  /**
+   * Implicitly adds [[TweenOps]][A] to any `A` with [[Numeric]].
+   *
+   * This is possible because any typeclass implementing [[Numeric]] should
+   * already have `+`, `-`, and `*` operations that [[TweenOps]] can use.
+   *
+   * @param value the underlying numeric value
+   * @tparam A a type extending [[Numeric]]
+   * @author Hawk Weisman
+   */
+  implicit class TwopsyNumeric[A : Numeric](val value: A)
   extends TweenOps[TwopsyNumeric[A]] {
-    def *(fraction: Float): TwopsyNumeric[A]
+
+    override def *(fraction: Float): TwopsyNumeric[A]
       = value * fraction
-    def +(other: TwopsyNumeric[A]): TwopsyNumeric[A]
+    override def +(other: TwopsyNumeric[A]): TwopsyNumeric[A]
       = value + other
-    def -(other: TwopsyNumeric[A]): TwopsyNumeric[A]
+    override def -(other: TwopsyNumeric[A]): TwopsyNumeric[A]
       = value - other
+
   }
   class AnimationTarget[T <: TweenOps[T]](var value: T) {
   }

--- a/src/main/scala/me/arcticlight/animations/ScalaTween.scala
+++ b/src/main/scala/me/arcticlight/animations/ScalaTween.scala
@@ -35,16 +35,15 @@ object ScalaTween {
       = this + (other - this) * fease(fraction)
   }
   implicit def unwrapTweenOps[T <: TweenOps[T]](ops: TweenOps[T]): T = ops
-  implicit def floatToTwops(float: Float): TweenOps[FloatWithTwops]
-    = FloatWithTwops(float)
   implicit def removeTwops(twops: FloatWithTwops): Float = twops.float
-  final case class FloatWithTwops(float: Float) extends TweenOps[FloatWithTwops] {
+  implicit class FloatWithTwops(val float: Float)
+  extends TweenOps[FloatWithTwops] {
     def *(fraction: Float): FloatWithTwops
-      = FloatWithTwops(float * fraction)
+      = float * fraction
     def +(other: FloatWithTwops): FloatWithTwops
-      = FloatWithTwops(float * other)
+      = float * other
     def -(other: FloatWithTwops): FloatWithTwops
-      = FloatWithTwops(float - other)
+      = float - other
   }
   class AnimationTarget[T <: TweenOps[T]](var value: T) {
   }

--- a/src/main/scala/me/arcticlight/animations/TweenOps.scala
+++ b/src/main/scala/me/arcticlight/animations/TweenOps.scala
@@ -1,0 +1,106 @@
+package me.arcticlight.animations
+
+trait TweenOps[A]  {
+  /**
+   * Scalar multiply (Tween operation) multiplies this value by a fraction
+   * and returns the result
+   * @param a The value to multiply
+   * @param f A [[Float]] value between 0 and 1, inclusive
+   * @return a T scaled by multiplying it with the scalar `fraction` amount
+   */
+  def mult[B : Fractional](a: A, b: B): A
+
+  /**
+   * Add (Tween operation) adds together this object and the parameter and
+   * returns the result
+   * @param a The first value to work with
+   * @param b Another [[T]] to add to this one
+   * @return The result of adding together `a` and `b`
+   */
+  def add(a: A, b: A): A
+
+  /**
+   * Subtract (Tween operation) subtracts the parameter from this object
+   * and returns the result.
+   * @param a The first value to work with
+   * @param b Another [[T]] to subtract from this one
+   * @return The result of subtracting `b` from `a`
+   */
+  def subt(a: A, b: A): A
+
+  /**
+   * Perform linear interpolation using TweenOps.
+   * @param a The value to start with
+   * @param b the other [[T]] with which to lerp to
+   */
+  def lerp(a: A, b: A, fraction: Float): A
+    = add(a, mult(subt(b,a), fraction))
+
+  def withEase(ease: (Float) => Float): WithEase = new WithEase(ease)
+
+  class WithEase(ease: (Float) => Float) extends TweenOps[A] {
+    /**
+     * Scalar multiply (Tween operation) multiplies this value by a fraction
+     * and returns the result
+     * @param a The value to multiply
+     * @param f A [[Float]] value between 0 and 1, inclusive
+     * @return a T scaled by multiplying it with the scalar `f` amount
+     */
+    override def mult[B : Fractional](a: A, b: B): A
+      = TweenOps.this.mult(a,b)
+
+    /**
+     * Subtract (Tween operation) subtracts the parameter from this object
+     * and returns the result.
+     * @param a The first value to work with
+     * @param b Another [[T]] to subtract from this one
+     * @return The result of subtracting `b` from `a`
+     */
+    override def subt(a: A, b: A): A
+      = TweenOps.this.subt(a,b)
+
+    /**
+     * Add (Tween operation) adds together this object and the parameter
+     * and returns the result
+     * @param a The first value to work with
+     * @param b Another [[T]] to add to this one
+     * @return The result of adding together `a` and `b`
+     */
+    override def add(a: A, b: A): A
+      = TweenOps.this.add(a,b)
+
+    override def lerp(a: A, b: A, f: Float): A
+      = add(a, mult(subt(b,a), ease(f)))
+  }
+}
+object TweenOps {
+  implicit object FloatHasTweenOps extends TweenOps[Float] {
+    /**
+     * Scalar multiply (Tween operation) multiplies this value by a fraction
+     * and returns the result
+     * @param a The value to multiply
+     * @param f A [[Float]] value between 0 and 1, inclusive
+     * @return a T scaled by multiplying it with the scalar `fraction` amount
+     */
+    override def mult[B : Fractional](a: Float, b: B): Float
+      = a * implicitly[Numeric[B]].toFloat(b)
+
+    /**
+     * Subtract (Tween operation) subtracts the parameter from this object
+     * and returns the result.
+     * @param a The first value to work with
+     * @param b Another [[Float]] to subtract from this one
+     * @return The result of subtracting `b` from `a`
+     */
+    override def subt(a: Float, b: Float): Float = a * b
+
+    /**
+     * Add (Tween operation) adds together this object and the parameter and
+     * returns the result
+     * @param a The first value to work with
+     * @param b Another [[Float]] to add to this one
+     * @return The result of adding together `this` and `other`
+     */
+    override def add(a: Float, b: Float): Float = a + b
+  }
+}


### PR DESCRIPTION
Nothing major in this PR, but some small assorted changes:
- Makes `FloatHasTweenOps` evidence an object instead of a class, de-breaking the `main` method.
- Made `TweenOps` right scalars open for all `A : Fractional`
- Code style improvements (Scala style guide compliance)
- Split `TweenOps` into its own file
